### PR TITLE
[DONE] add tokenId to api header 

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -104,7 +104,7 @@ function App() {
               updatestate={updatestate}
               idToken={idToken}
             />
-            <TGTList toukouState={toukouState} />
+            <TGTList toukouState={toukouState} idToken={idToken} />
           </>
         ) : (
           <>

--- a/src/components/TGTInput.js
+++ b/src/components/TGTInput.js
@@ -61,6 +61,7 @@ function TGTInput(props) {
     var request = new XMLHttpRequest();
     request.open("Post", API_ENDPOINT + "v1/threetter/posts", true);
     request.setRequestHeader("Content-type", "application/json; charset=utf-8");
+    request.setRequestHeader("x-auth-token", props.idToken);
     setTGT1("");
     setTGT2("");
     setTGT3("");

--- a/src/components/TGTList.js
+++ b/src/components/TGTList.js
@@ -29,7 +29,7 @@ function TGTList(props) {
       let res;
       let data;
       try {
-        res = await fetch(url, { method, header, body });
+        res = await fetch(url, { method, header });
         data = await res.json();
         setTGTList(data);
       } catch (e) {

--- a/src/components/TGTList.js
+++ b/src/components/TGTList.js
@@ -19,10 +19,17 @@ function TGTList(props) {
     const loadTGTList = async () => {
       const API_ENDPOINT = config.THREETER_API_ENDPOINT;
       const url = API_ENDPOINT + "v1/threetter/posts";
+      const headers = {};
+      headers["Accept"] = "application/json";
+      headers["Content-Type"] = "application/json";
+      headers["x-auth-token"] = props.idToken;
+      const header = JSON.stringify(headers);
+      const method = "GET";
+
       let res;
       let data;
       try {
-        res = await fetch(url, { method: "GET" });
+        res = await fetch(url, { method, header, body });
         data = await res.json();
         setTGTList(data);
       } catch (e) {


### PR DESCRIPTION
下記仕様変更に対応する

Backend: GoogleAuthAPIでアクセストークンの生死を確認する
のフロントからみた仕様です。
全APIの呼出時、Headerに以下のトークンを追加してほしいです。
◆リクエストヘッダ
Key：x-auth-token
Value：GoogleAPIのtoken_id項目
◆レスポンス
認証情報が確認できた時：HTTPステータスコード200、今まで通りの処理を実施
認証情報が確認できなかった※時：HTTPステータスコード403
※トークンが付与されていない場合、Googleに問合せた結果でinavlidと判定された場合、問合せた結果、DBのメールアドレスと一致しない場合 (edited) 